### PR TITLE
feat: GraphQL+TanStack Query基盤を実装し、ポケモン図鑑ページを作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ count.txt
 
 *storybook.log
 storybook-static
+
+src/shared/api/gen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,11 @@ bun dev
 - 各種パッケージのスクリプトは @./package.json の scripts を参照してください。
 - ライブラリのバージョンについてはチルダやキャレットは使用せず、 `x.x.x` と固定化し、可能な限り最新バージョンを使用してください。
 
-### 重要な注意事項
-- `src/app/routes/routeTree.gen.ts` は TanStack Router による自動生成ファイルのため、編集しないでください。
+### コーディングについて
+- 相対パスを使用せず、 @tsconfig.json に記載されたパスエイリアスを使ってください。
+
+### 注意事項
+- @src/app/routes/routeTree.gen.ts およびは @src/shared/api/gen は自動生成ファイルのため、編集しないでください。
 
 ## 🌿 Git運用規則
 

--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,13 @@
       },
       "a11y": {
         "useKeyWithClickEvents": "off"
+      },
+      "performance": {
+        "noBarrelFile": "error",
+        "noReExportAll": "error"
+      },
+      "nursery": {
+        "noImportCycles": "error"
       }
     }
   },
@@ -28,7 +35,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!**/routeTree.gen.ts", "!src/shared/api/graphql"]
+    "includes": ["**", "!**/routeTree.gen.ts", "!src/shared/api/gen"]
   },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "javascript": {

--- a/codegen.ts
+++ b/codegen.ts
@@ -4,7 +4,7 @@ const config: CodegenConfig = {
   schema: 'https://graphql.pokeapi.co/v1beta2',
   documents: ['./src/**/*.(tsx|ts)'],
   generates: {
-    './src/shared/api/graphql/': {
+    './src/shared/api/gen/': {
       preset: 'client',
       plugins: [],
     },

--- a/src/app/providers/query-provider.tsx
+++ b/src/app/providers/query-provider.tsx
@@ -1,12 +1,13 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
+import type React from 'react'
+import { queryClient } from '@/shared/api/query-client'
 
 export function getContext() {
-  const queryClient = new QueryClient()
   return {
     queryClient,
   }
 }
 
-export function Provider({ children, queryClient }: { children: React.ReactNode; queryClient: QueryClient }) {
+export function Provider({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 }

--- a/src/app/providers/theme/ThemeProvider.tsx
+++ b/src/app/providers/theme/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from 'jotai'
 import { type ReactNode, useEffect } from 'react'
-import { colorSetAtom, themeAtom } from '@/features/changeTheme'
+import { colorSetAtom, themeAtom } from '@/features/changeTheme/model/theme'
 
 interface ThemeProviderProps {
   children: ReactNode

--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import logo from '../ui/assets/logo.svg'
 
 export const Route = createFileRoute('/')({
@@ -13,22 +13,36 @@ function App() {
         <p>
           Edit <code>src/routes/index.tsx</code> and save to reload.
         </p>
-        <a
-          className="text-[#61dafb] hover:underline"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-        <a
-          className="text-[#61dafb] hover:underline"
-          href="https://tanstack.com"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn TanStack
-        </a>
+
+        {/* ポケモンページへのリンク */}
+        <div className="flex flex-col gap-4 mt-8">
+          <Link to="/pokemon" className="text-[#61dafb] hover:underline text-xl font-bold">
+            🐾 ポケモン図鑑
+          </Link>
+
+          <Link to="/demo/tanstack-query" className="text-[#61dafb] hover:underline">
+            TanStack Query Demo
+          </Link>
+        </div>
+
+        <div className="flex flex-col gap-2 mt-8">
+          <a
+            className="text-[#61dafb] hover:underline"
+            href="https://reactjs.org"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn React
+          </a>
+          <a
+            className="text-[#61dafb] hover:underline"
+            href="https://tanstack.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn TanStack
+          </a>
+        </div>
       </header>
     </div>
   )

--- a/src/app/routes/pokemon.tsx
+++ b/src/app/routes/pokemon.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { PokemonListPage } from '@/pages/pokemon/ui/PokemonListPage'
+
+export const Route = createFileRoute('/pokemon')({
+  component: PokemonListPage,
+})

--- a/src/app/routes/routeTree.gen.ts
+++ b/src/app/routes/routeTree.gen.ts
@@ -9,9 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './__root'
+import { Route as PokemonRouteImport } from './pokemon'
 import { Route as IndexRouteImport } from './index'
 import { Route as DemoTanstackQueryRouteImport } from './demo.tanstack-query'
 
+const PokemonRoute = PokemonRouteImport.update({
+  id: '/pokemon',
+  path: '/pokemon',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -25,32 +31,43 @@ const DemoTanstackQueryRoute = DemoTanstackQueryRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/pokemon': typeof PokemonRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/pokemon': typeof PokemonRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/pokemon': typeof PokemonRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/demo/tanstack-query'
+  fullPaths: '/' | '/pokemon' | '/demo/tanstack-query'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/demo/tanstack-query'
-  id: '__root__' | '/' | '/demo/tanstack-query'
+  to: '/' | '/pokemon' | '/demo/tanstack-query'
+  id: '__root__' | '/' | '/pokemon' | '/demo/tanstack-query'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  PokemonRoute: typeof PokemonRoute
   DemoTanstackQueryRoute: typeof DemoTanstackQueryRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/pokemon': {
+      id: '/pokemon'
+      path: '/pokemon'
+      fullPath: '/pokemon'
+      preLoaderRoute: typeof PokemonRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -70,6 +87,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  PokemonRoute: PokemonRoute,
   DemoTanstackQueryRoute: DemoTanstackQueryRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/features/changeTheme/index.ts
+++ b/src/features/changeTheme/index.ts
@@ -1,2 +1,0 @@
-export type { ColorSet, Theme } from './model/theme'
-export { colorSetAtom, themeAtom } from './model/theme'

--- a/src/pages/pokemon/api/usePokemonList.ts
+++ b/src/pages/pokemon/api/usePokemonList.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query'
+import { graphql } from '@/shared/api/gen'
+import { graphQLClient } from '@/shared/api/graphql-client'
+
+const GET_POKEMON_LIST = graphql(`
+  query GetPokemonList($limit: Int!, $offset: Int!) {
+    pokemon(limit: $limit, offset: $offset) {
+      id
+      name
+      pokemonsprites {
+        sprites
+      }
+    }
+  }
+`)
+
+// ポケモン一覧取得（名前と画像）
+export function usePokemonList(page: number = 1, limit: number = 10) {
+  const offset = (page - 1) * limit
+
+  return useQuery({
+    queryKey: ['pokemonList', page, limit],
+    queryFn: () => {
+      return graphQLClient.request(GET_POKEMON_LIST, {
+        limit,
+        offset,
+      })
+    },
+  })
+}

--- a/src/pages/pokemon/ui/PokemonListPage.tsx
+++ b/src/pages/pokemon/ui/PokemonListPage.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import { usePokemonList } from '../api/usePokemonList'
+import { PokemonGrid } from './components/PokemonGrid'
+import { PokemonPagination } from './components/PokemonPagination'
+
+export function PokemonListPage() {
+  const [currentPage, setCurrentPage] = useState(1)
+  const limit = 10
+
+  const { data, isLoading, error } = usePokemonList(currentPage, limit)
+
+  const totalPages = Math.ceil(1000 / limit) // ポケモンは約1000体いると仮定
+
+  return (
+    <div className="min-h-screen bg-background p-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold mb-8 text-center text-foreground">ポケモン図鑑</h1>
+
+        {error && (
+          <div className="text-center mb-8">
+            <p className="text-destructive text-xl">エラー: {error.message}</p>
+          </div>
+        )}
+
+        <PokemonGrid pokemon={data?.pokemon} isLoading={isLoading} currentPage={currentPage} limit={limit} />
+
+        {!error && (
+          <PokemonPagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/pokemon/ui/components/PokemonCard.tsx
+++ b/src/pages/pokemon/ui/components/PokemonCard.tsx
@@ -1,0 +1,37 @@
+import type { GetPokemonListQuery } from '@/shared/api/gen/graphql'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/components/Card/Card'
+
+// スプライトデータの型定義
+interface SpriteData {
+  front_default?: string
+  [key: string]: unknown
+}
+
+type Pokemon = GetPokemonListQuery['pokemon'][number]
+
+interface PokemonCardProps {
+  pokemon: Pokemon
+}
+
+export function PokemonCard({ pokemon }: PokemonCardProps) {
+  return (
+    <Card className="hover:shadow-xl transition-shadow">
+      <CardHeader className="text-center">
+        <CardTitle className="text-xl">{pokemon.name}</CardTitle>
+        <CardDescription>#{pokemon.id}</CardDescription>
+      </CardHeader>
+      <CardContent className="text-center">
+        {pokemon.pokemonsprites.length > 0 && (
+          <img
+            src={(pokemon.pokemonsprites[0]?.sprites as SpriteData)?.front_default}
+            alt={pokemon.name}
+            className="mx-auto w-24 h-24"
+            onError={(e) => {
+              e.currentTarget.style.display = 'none'
+            }}
+          />
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/pages/pokemon/ui/components/PokemonGrid.tsx
+++ b/src/pages/pokemon/ui/components/PokemonGrid.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from 'react'
+import type { GetPokemonListQuery } from '@/shared/api/gen/graphql'
+import { PokemonCard } from './PokemonCard'
+import { PokemonSkeleton } from './PokemonSkeleton'
+
+type Pokemon = GetPokemonListQuery['pokemon'][number]
+
+interface PokemonGridProps {
+  pokemon?: Pokemon[]
+  isLoading: boolean
+  currentPage: number
+  limit: number
+}
+
+export function PokemonGrid({ pokemon, isLoading, currentPage, limit }: PokemonGridProps) {
+  // スケルトン用のユニークキーを事前生成
+  const skeletonKeys = useMemo(
+    () => Array.from({ length: limit }, (_, i) => `skeleton-${currentPage}-${Date.now()}-${i}`),
+    [currentPage, limit],
+  )
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {skeletonKeys.map((key) => (
+          <PokemonSkeleton key={key} />
+        ))}
+      </div>
+    )
+  }
+
+  if (!pokemon || pokemon.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground text-xl">ポケモンが見つかりませんでした</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {pokemon.map((pokemonItem) => (
+        <PokemonCard key={pokemonItem.id} pokemon={pokemonItem} />
+      ))}
+    </div>
+  )
+}

--- a/src/pages/pokemon/ui/components/PokemonPagination.tsx
+++ b/src/pages/pokemon/ui/components/PokemonPagination.tsx
@@ -1,0 +1,65 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/shared/ui/components/Pagination/Pagination'
+
+interface PokemonPaginationProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+export function PokemonPagination({ currentPage, totalPages, onPageChange }: PokemonPaginationProps) {
+  const handlePrevious = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
+    if (currentPage > 1) onPageChange(currentPage - 1)
+  }
+
+  const handleNext = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
+    if (currentPage < totalPages) onPageChange(currentPage + 1)
+  }
+
+  const handlePageClick = (page: number) => (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
+    onPageChange(page)
+  }
+
+  return (
+    <Pagination className="mt-8">
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" size="default" onClick={handlePrevious} />
+        </PaginationItem>
+
+        {/* 簡単なページネーション表示 */}
+        {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
+          const page = Math.max(1, currentPage - 2) + i
+          if (page > totalPages) return null
+
+          return (
+            <PaginationItem key={page}>
+              <PaginationLink
+                href="#"
+                size="default"
+                isActive={currentPage === page}
+                onClick={handlePageClick(page)}
+                className={currentPage === page ? 'bg-primary text-primary-foreground hover:bg-primary/90' : ''}
+              >
+                {page}
+              </PaginationLink>
+            </PaginationItem>
+          )
+        })}
+
+        <PaginationItem>
+          <PaginationNext href="#" size="default" onClick={handleNext} />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  )
+}

--- a/src/pages/pokemon/ui/components/PokemonSkeleton.tsx
+++ b/src/pages/pokemon/ui/components/PokemonSkeleton.tsx
@@ -1,0 +1,16 @@
+import { Card, CardContent, CardHeader } from '@/shared/ui/components/Card/Card'
+import { Skeleton } from '@/shared/ui/components/Skelton/Skeleton'
+
+export function PokemonSkeleton() {
+  return (
+    <Card>
+      <CardHeader className="text-center">
+        <Skeleton className="h-6 w-32 mx-auto mb-2" />
+        <Skeleton className="h-4 w-16 mx-auto" />
+      </CardHeader>
+      <CardContent className="text-center">
+        <Skeleton className="h-24 w-24 mx-auto rounded-full" />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/shared/api/graphql-client.ts
+++ b/src/shared/api/graphql-client.ts
@@ -1,0 +1,7 @@
+import { GraphQLClient } from 'graphql-request'
+
+// ポケモンAPI GraphQL エンドポイント
+const GRAPHQL_ENDPOINT = 'https://graphql.pokeapi.co/v1beta2'
+
+// GraphQL クライアント
+export const graphQLClient = new GraphQLClient(GRAPHQL_ENDPOINT)

--- a/src/shared/api/query-client.ts
+++ b/src/shared/api/query-client.ts
@@ -1,0 +1,25 @@
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query'
+
+// TanStack Query クライアント
+export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error) => {
+      console.error('Query エラー:', error)
+    },
+  }),
+  mutationCache: new MutationCache({
+    onError: (error) => {
+      console.error('Mutation エラー:', error)
+    },
+  }),
+  defaultOptions: {
+    queries: {
+      retry: 3,
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      refetchOnWindowFocus: false,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+})

--- a/src/shared/ui/components/Card/Card.stories.tsx
+++ b/src/shared/ui/components/Card/Card.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from './Card'
+
+const meta = {
+  title: 'UI/Card',
+  component: Card,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes',
+    },
+  },
+} satisfies Meta<typeof Card>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <Card className="w-80">
+      <CardHeader>
+        <CardTitle>Card Title</CardTitle>
+        <CardDescription>This is a description of the card content.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>Card content goes here. This can be any content you want to display.</p>
+      </CardContent>
+      <CardFooter>
+        <p className="text-sm text-muted-foreground">Card footer</p>
+      </CardFooter>
+    </Card>
+  ),
+}
+
+export const Simple: Story = {
+  render: () => (
+    <Card className="w-80">
+      <CardContent>
+        <p>A simple card with just content.</p>
+      </CardContent>
+    </Card>
+  ),
+}
+
+export const WithAction: Story = {
+  render: () => (
+    <Card className="w-80">
+      <CardHeader>
+        <CardTitle>Settings</CardTitle>
+        <CardDescription>Manage your account settings</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span>Email notifications</span>
+            <input type="checkbox" />
+          </div>
+          <div className="flex items-center justify-between">
+            <span>Push notifications</span>
+            <input type="checkbox" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  ),
+}
+
+export const Hover: Story = {
+  render: () => (
+    <Card className="w-80 hover:shadow-xl transition-shadow cursor-pointer">
+      <CardHeader>
+        <CardTitle>Interactive Card</CardTitle>
+        <CardDescription>This card has hover effects</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>Hover over this card to see the shadow effect.</p>
+      </CardContent>
+    </Card>
+  ),
+}

--- a/src/shared/ui/components/Card/Card.tsx
+++ b/src/shared/ui/components/Card/Card.tsx
@@ -1,0 +1,54 @@
+import type * as React from 'react'
+
+import { cn } from '@/shared/ui/utils/shadcnUtils.ts'
+
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card"
+      className={cn('bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm', className)}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-title" className={cn('leading-none font-semibold', className)} {...props} />
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-description" className={cn('text-muted-foreground text-sm', className)} {...props} />
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-footer" className={cn('flex items-center px-6 [.border-t]:pt-6', className)} {...props} />
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent }

--- a/src/shared/ui/components/Pagination/Pagination.stories.tsx
+++ b/src/shared/ui/components/Pagination/Pagination.stories.tsx
@@ -1,0 +1,181 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from './Pagination'
+
+const meta = {
+  title: 'UI/Pagination',
+  component: Pagination,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Pagination>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            1
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">2</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+}
+
+export const WithEllipsis: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            5
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">6</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">10</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+}
+
+export const Interactive: Story = {
+  render: function InteractivePagination() {
+    const [currentPage, setCurrentPage] = useState(1)
+    const totalPages = 10
+
+    const handlePageClick = (page: number) => (e: React.MouseEvent) => {
+      e.preventDefault()
+      setCurrentPage(page)
+    }
+
+    const handlePrevious = (e: React.MouseEvent) => {
+      e.preventDefault()
+      if (currentPage > 1) setCurrentPage(currentPage - 1)
+    }
+
+    const handleNext = (e: React.MouseEvent) => {
+      e.preventDefault()
+      if (currentPage < totalPages) setCurrentPage(currentPage + 1)
+    }
+
+    return (
+      <div className="space-y-4">
+        <p className="text-center text-sm text-muted-foreground">
+          Current page: {currentPage} / {totalPages}
+        </p>
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious href="#" onClick={handlePrevious} />
+            </PaginationItem>
+
+            {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
+              const page = Math.max(1, currentPage - 2) + i
+              if (page > totalPages) return null
+
+              return (
+                <PaginationItem key={page}>
+                  <PaginationLink
+                    href="#"
+                    isActive={currentPage === page}
+                    onClick={handlePageClick(page)}
+                    className={currentPage === page ? 'bg-primary text-primary-foreground hover:bg-primary/90' : ''}
+                  >
+                    {page}
+                  </PaginationLink>
+                </PaginationItem>
+              )
+            })}
+
+            <PaginationItem>
+              <PaginationNext href="#" onClick={handleNext} />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </div>
+    )
+  },
+}
+
+export const Large: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">2</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            4
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">5</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">6</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">7</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+}

--- a/src/shared/ui/components/Pagination/Pagination.tsx
+++ b/src/shared/ui/components/Pagination/Pagination.tsx
@@ -1,0 +1,98 @@
+import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from 'lucide-react'
+import type * as React from 'react'
+import { type Button, buttonVariants } from '@/shared/ui/components/Button/Button'
+import { cn } from '@/shared/ui/utils/shadcnUtils.ts'
+
+function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
+  return (
+    <nav
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn('mx-auto flex w-full justify-center', className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({ className, ...props }: React.ComponentProps<'ul'>) {
+  return <ul data-slot="pagination-content" className={cn('flex flex-row items-center gap-1', className)} {...props} />
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, 'size'> &
+  React.ComponentProps<'a'>
+
+function PaginationLink({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? 'page' : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? 'outline' : 'ghost',
+          size,
+        }),
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function PaginationPrevious({ className, size = 'default', ...props }: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size={size}
+      className={cn('gap-1 px-2.5 sm:pl-2.5', className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({ className, size = 'default', ...props }: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size={size}
+      className={cn('gap-1 px-2.5 sm:pr-2.5', className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn('flex size-9 items-center justify-center', className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/src/shared/ui/components/Skelton/Skeleton.stories.tsx
+++ b/src/shared/ui/components/Skelton/Skeleton.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Card, CardContent, CardHeader } from '../Card/Card'
+import { Skeleton } from './Skeleton'
+
+const meta = {
+  title: 'UI/Skeleton',
+  component: Skeleton,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes for styling',
+    },
+  },
+} satisfies Meta<typeof Skeleton>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => <Skeleton className="h-4 w-64" />,
+}
+
+export const Circle: Story = {
+  render: () => <Skeleton className="h-16 w-16 rounded-full" />,
+}
+
+export const Rectangle: Story = {
+  render: () => <Skeleton className="h-32 w-80 rounded-lg" />,
+}
+
+export const Text: Story = {
+  render: () => (
+    <div className="space-y-2">
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-4 w-64" />
+      <Skeleton className="h-4 w-56" />
+    </div>
+  ),
+}
+
+export const Avatar: Story = {
+  render: () => (
+    <div className="flex items-center space-x-4">
+      <Skeleton className="h-12 w-12 rounded-full" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-3 w-24" />
+      </div>
+    </div>
+  ),
+}
+
+export const CardLayout: Story = {
+  render: () => (
+    <Card className="w-80">
+      <CardHeader>
+        <Skeleton className="h-6 w-48 mb-2" />
+        <Skeleton className="h-4 w-32" />
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          <Skeleton className="h-32 w-full rounded-lg" />
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-4/5" />
+            <Skeleton className="h-4 w-3/5" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  ),
+}

--- a/src/shared/ui/components/Skelton/Skeleton.tsx
+++ b/src/shared/ui/components/Skelton/Skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from '@/shared/ui/utils/shadcnUtils.ts'
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="skeleton" className={cn('bg-accent animate-pulse rounded-md', className)} {...props} />
+}
+
+export { Skeleton }

--- a/src/shared/ui/components/index.ts
+++ b/src/shared/ui/components/index.ts
@@ -1,1 +1,0 @@
-export { Button, buttonVariants } from './Button/Button.tsx'


### PR DESCRIPTION
- closed #14 
## Summary
- GraphQLクライアント設定を追加し、TanStack QueryとPokeAPIを連携
- shadcn/uiのCard、Pagination、Skeletonコンポーネントを統合
- ポケモン一覧表示機能をFSD 2.1アーキテクチャで実装
- biomeの設定強化とbarrel fileの制限追加

## 主な変更内容
- **GraphQL基盤構築**: GraphQLクライアントとCodeGeneratorの設定
- **共通UIコンポーネント**: Card、Pagination、Skeletonの追加
- **ポケモン図鑑機能**: 一覧表示、ページネーション、ローディング状態対応
- **FSD準拠**: Pages層での実装とAPI分離
- **開発環境改善**: biomeルール強化、自動生成ファイルの除外設定

## 技術的な詳細
- TanStack QueryとGraphQL Requestの統合
- PokeAPI GraphQLエンドポイントとの連携
- レスポンシブ対応のグリッドレイアウト
- エラーハンドリングとローディング状態の実装

## Test plan
- [ ] ポケモン一覧ページ（/pokemon）の表示確認
- [ ] ページネーション機能の動作確認  
- [ ] ローディング状態とエラー処理の確認
- [ ] レスポンシブデザインの確認
- [ ] GraphQL Code Generatorの動作確認